### PR TITLE
    Fix platform-specific preprocessor directive for Linux

### DIFF
--- a/include/gamespy/gscommon.h
+++ b/include/gamespy/gscommon.h
@@ -19,7 +19,8 @@
 #endif
 
 // Support all Linux compiler defines into one expected define
-#if !defined(_LINUX) && (defined(__linux__) || defined(__linux))
+// See https://github.com/cpredef/predef/blob/master/OperatingSystems.md
+#if !defined(_LINUX) && (defined(__linux__) || defined(__linux) || defined(linux))
 #define _LINUX
 #endif
 

--- a/include/gamespy/gscommon.h
+++ b/include/gamespy/gscommon.h
@@ -19,7 +19,7 @@
 #endif
 
 // Support all Linux compiler defines into one expected define
-#ifndef _LINUX && (defined(__linux__) || defined(__linux))
+#if !defined(_LINUX) && (defined(__linux__) || defined(__linux))
 #define _LINUX
 #endif
 

--- a/include/gamespy/gscommon.h
+++ b/include/gamespy/gscommon.h
@@ -18,6 +18,11 @@
 #define UNIQUEID // enable unique id support
 #endif
 
+// Support all Linux compiler defines into one expected define
+#ifndef _LINUX && (defined(__linux__) || defined(__linux))
+#define _LINUX
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 #include "gsplatform.h"

--- a/src/common/gsdebug.c
+++ b/src/common/gsdebug.c
@@ -63,7 +63,7 @@ gsiDebugCallback(GSIDebugCategory category, GSIDebugType type, GSIDebugLevel lev
     vsprintf(string, format, params);
     OutputDebugStringA(string);
 
-#elif defined(_LINUX) || defined(_MACOSX)
+#elif defined(__linux__) || defined(_MACOSX)
     //static char    string[256];
     //vsprintf(string, format, params);
     vprintf(format, params);

--- a/src/common/gsdebug.c
+++ b/src/common/gsdebug.c
@@ -63,7 +63,7 @@ gsiDebugCallback(GSIDebugCategory category, GSIDebugType type, GSIDebugLevel lev
     vsprintf(string, format, params);
     OutputDebugStringA(string);
 
-#elif defined(__linux__) || defined(_MACOSX)
+#elif defined(_LINUX) || defined(_MACOSX)
     //static char    string[256];
     //vsprintf(string, format, params);
     vprintf(format, params);


### PR DESCRIPTION
Replaced `_LINUX` with `__linux__` to align with standard platform macros.

This ensures proper compilation and debugging functionality on Linux systems.

No other logic or functionality was affected.