### PR TITLE
add support for MinGW32 compiler

### DIFF
--- a/src/common/gsplatformutil.c
+++ b/src/common/gsplatformutil.c
@@ -1706,7 +1706,11 @@ static void GenerateID(char* keyval)
     LARGE_INTEGER l1;
     UINT seed;
     if (QueryPerformanceCounter(&l1))
+#ifdef __MINGW32__
+        seed = (l1.u.LowPart ^ l1.u.HighPart);
+#else
         seed = (l1.LowPart ^ l1.HighPart);
+#endif
     else
         seed = 0;
     Util_RandSeed(seed ^ GetTickCount() ^ (unsigned long)time(NULL) ^ clock());

--- a/src/gt2/gt2encode.c
+++ b/src/gt2/gt2encode.c
@@ -107,6 +107,16 @@ void gt2MemCopy(char* out, char const* in, int size)
 
 #else
 
+#ifdef __MINGW32__
+#define GT_ENCODE_ELEM(TYPE, b, l, args)                                                                               \
+    {                                                                                                                  \
+        if (l < sizeof(TYPE))                                                                                          \
+            return -1;                                                                                                 \
+        TYPE temp = va_arg(*args, TYPE);                                                                               \
+        gt2MemCopy(b, (const char*)&temp, sizeof(TYPE));                                                               \
+        return sizeof(TYPE);                                                                                           \
+    }
+#else
 #define GT_ENCODE_ELEM(TYPE, b, l, args)                                                                               \
     {                                                                                                                  \
         if (l < sizeof(TYPE))                                                                                          \
@@ -114,6 +124,7 @@ void gt2MemCopy(char* out, char const* in, int size)
         gt2MemCopy(b, (const char*)&va_arg(*args, TYPE), sizeof(TYPE));                                                \
         return sizeof(TYPE);                                                                                           \
     }
+#endif
 #define GT_DECODE_ELEM(TYPE, b, l, args)                                                                               \
     {                                                                                                                  \
         if (l < sizeof(TYPE))                                                                                          \


### PR DESCRIPTION
When cross compiling gamespy on MinGW32 a issue is encountered

**gt2encode.c**

```shell
src/gt2/gt2encode.c:114:36: error: lvalue required as unary ‘&’ operand
  114 |         gt2MemCopy(b, (const char*)&va_arg(*args, TYPE), sizeof(TYPE));    
```

**gsplatformutil.c**

```shell
src/common/gsplatformutil.c:1709:19: error: ‘LARGE_INTEGER’ has no member named ‘LowPart’
 1709 |         seed = (l1.LowPart ^ l1.HighPart);
```

## Changes

Add makro dedection for MinGW compiler.

## Vision

This is work for the ability to crosscompile ZH from linux to windows and in the future produce a native binary aswell.