### PR TITLE
Fix incorrect include when building against.

### DIFF
--- a/include/gamespy/gsplatform.h
+++ b/include/gamespy/gsplatform.h
@@ -63,7 +63,9 @@
 
 // WIN32
 #elif defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <limits.h>
 #include <time.h>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,13 @@ if(BUILD_SHARED_LIBS)
     set_target_properties(gamespy PROPERTIES ARCHIVE_OUTPUT_NAME gamespy_import WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
+# Handle including sockets library headers for consumers.
+if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+    if(GS_WINSOCK2)
+        target_compile_definitions(gamespy INTERFACE GSI_WINSOCK2)
+    endif()
+endif()
+
 if(GS_BUILD_TESTS)
     add_executable(chattest chat/chatc/chatc.c)
     target_link_libraries(chattest gamespy)


### PR DESCRIPTION
Wrong winsock header was included on targets linking to gamespy.