### PR TITLE
Disable assertions by default

### DIFF
--- a/include/gamespy/gcdkey/gcdkeys.h
+++ b/include/gamespy/gcdkey/gcdkeys.h
@@ -20,8 +20,6 @@ devsupport@gamespy.com
 extern "C" {
 #endif
 
-#define GUSE_ASSERTS
-
 /*****
 QR2CDKEY_INTEGRATION: This define controls where the functions needed to integrate
 the networking of the Query & Reporting 2 SDK and CDKey SDKs are available.


### PR DESCRIPTION
An assertion failed in `gcd_disconnect_user` when finishing the first Renegade campaign, because find_product could not find the product.

Disabling this assertion allows me to go to the second mission after finishing the first one, with renegade built in debug mode.